### PR TITLE
GNU/Hurd support for rump accessing pci in userspace via pci-arbiter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: c
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - libpciaccess-dev
+
 script:
   - git submodule update --init
   - ./buildrump.sh/buildrump.sh -T rumptools -s rumpsrc -V NOSTATICLIB=1 -qq -j16 checkout fullbuild

--- a/src-gnu/Makefile
+++ b/src-gnu/Makefile
@@ -1,16 +1,7 @@
 RUMPTOP= ${TOPRUMP}
 
-RUMPCOMP_USER_SRCS.rumpdev_pci=		pci_user-gnu.c experimentalUser.c mach_debugUser.c
-RUMPCOMP_USER_PATH.rumpdev_pci:=	${.PARSEDIR}
-RUMPCOMP_USER_CPPFLAGS.rumpdev_pci:=	-I${.PARSEDIR}
-RUMPCOMP_CPPFLAGS.rumpdev_pci:=		-I${.PARSEDIR}
-RUMPCOMP_MAKEFILEINC.rumpdev_pci:=	Makefile.inc
-
-.export RUMPCOMP_USER_SRCS.rumpdev_pci
-.export RUMPCOMP_USER_PATH.rumpdev_pci
-.export RUMPCOMP_USER_CPPFLAGS.rumpdev_pci
-.export RUMPCOMP_CPPFLAGS.rumpdev_pci
-.export RUMPCOMP_MAKEFILEINC.rumpdev_pci
+RUMPCOMP_MAKEFILEINC_rumpdev_pci:= ${.PARSEDIR}/Makefile.inc
+.export RUMPCOMP_MAKEFILEINC_rumpdev_pci
 
 .include "${RUMPTOP}/dev/Makefile.rumpdevcomp"
 

--- a/src-gnu/Makefile.inc
+++ b/src-gnu/Makefile.inc
@@ -1,4 +1,4 @@
-LDFLAGS += -lpciaccess
+LDFLAGS += -Wl,--no-as-needed -lpciaccess -Wl,--as-needed
 
 experimentalUser.c:
 	echo '#include <mach/experimental.defs>' \

--- a/src-gnu/Makefile.inc
+++ b/src-gnu/Makefile.inc
@@ -1,4 +1,13 @@
-LDFLAGS += -Wl,--no-as-needed -lpciaccess -Wl,--as-needed
+# make defs for gnu PCI component
+
+PCIDIR:=	${.PARSEDIR}
+.PATH:		${PCIDIR}
+
+RUMPCOMP_USER_SRCS=	pci_user-gnu.c experimentalUser.c mach_debugUser.c
+RUMPCOMP_USER_CPPFLAGS+=-I${PCIDIR}
+RUMPCOMP_CPPFLAGS+=	-I${PCIDIR}
+CPPFLAGS+=		-I${PCIDIR}
+LDFLAGS+= -Wl,--no-as-needed -lpciaccess -Wl,--as-needed
 
 experimentalUser.c:
 	echo '#include <mach/experimental.defs>' \

--- a/src-linux-uio/Makefile
+++ b/src-linux-uio/Makefile
@@ -1,14 +1,7 @@
 RUMPTOP= ${TOPRUMP}
 
-RUMPCOMP_USER_SRCS.rumpdev_pci=		pci_user-uio_linux.c
-RUMPCOMP_USER_PATH.rumpdev_pci:=	${.PARSEDIR}
-RUMPCOMP_USER_CPPFLAGS.rumpdev_pci:=	-I${.PARSEDIR}
-RUMPCOMP_CPPFLAGS.rumpdev_pci:=		-I${.PARSEDIR}
-
-.export RUMPCOMP_USER_SRCS.rumpdev_pci
-.export RUMPCOMP_USER_PATH.rumpdev_pci
-.export RUMPCOMP_USER_CPPFLAGS.rumpdev_pci
-.export RUMPCOMP_CPPFLAGS.rumpdev_pci
+RUMPCOMP_MAKEFILEINC_rumpdev_pci:= ${.PARSEDIR}/Makefile.inc
+.export RUMPCOMP_MAKEFILEINC_rumpdev_pci
 
 .include "${RUMPTOP}/dev/Makefile.rumpdevcomp"
 

--- a/src-linux-uio/Makefile.inc
+++ b/src-linux-uio/Makefile.inc
@@ -1,0 +1,9 @@
+# make defs for linux PCI component
+
+PCIDIR:=	${.PARSEDIR}
+.PATH:		${PCIDIR}
+
+RUMPCOMP_USER_SRCS=	pci_user-uio_linux.c
+RUMPCOMP_USER_CPPFLAGS+=-I${PCIDIR}
+RUMPCOMP_CPPFLAGS+=	-I${PCIDIR}
+CPPFLAGS+=		-I${PCIDIR}


### PR DESCRIPTION
I think previously the "dev" was being used as the lookup parameter to match a device to a bus/dev/func and thus probably matched to the wrong device when trying to read and write to config space?  This change allows the memory regions to be looked up and mapped from libpciaccess and also chooses the correct device when searching by bus/dev/func.

Privileged ports are not needed for pci access via pci-arbiter anymore because there is a hurdish access method in libpciaccess that uses the dedicated pci-arbiter translator (pending review here: https://gitlab.freedesktop.org/xorg/lib/libpciaccess/merge_requests/2).

How do I test this change on hurd?  As a basic test, I want to be able to expose a rump disk device using pci access in userspace and present a device node to the host that can be used to read() and write() to the disk hardware.  I could not find any examples of using this package in the rump book.